### PR TITLE
fix depth of resnet/preresnet on cifar10/cifar100

### DIFF
--- a/cifar.py
+++ b/cifar.py
@@ -64,6 +64,8 @@ parser.add_argument('--arch', '-a', metavar='ARCH', default='resnet20',
                         ' | '.join(model_names) +
                         ' (default: resnet18)')
 parser.add_argument('--depth', type=int, default=29, help='Model depth.')
+parser.add_argument('--block-name', type=str, default='BasicBlock',
+                    help='the building block for Resnet and Preresnet: BasicBlock, Bottleneck (default: Basicblock for cifar10/cifar100)')
 parser.add_argument('--cardinality', type=int, default=8, help='Model cardinality (group).')
 parser.add_argument('--widen-factor', type=int, default=4, help='Widen factor. 4 -> 64, 8 -> 128, ...')
 parser.add_argument('--growthRate', type=int, default=12, help='Growth rate for DenseNet.')
@@ -161,6 +163,7 @@ def main():
         model = models.__dict__[args.arch](
                     num_classes=num_classes,
                     depth=args.depth,
+                    block_name=args.block_name,
                 )
     else:
         model = models.__dict__[args.arch](num_classes=num_classes)
@@ -168,7 +171,6 @@ def main():
     model = torch.nn.DataParallel(model).cuda()
     cudnn.benchmark = True
     print('    Total params: %.2fM' % (sum(p.numel() for p in model.parameters())/1000000.0))
-
     criterion = nn.CrossEntropyLoss()
     optimizer = optim.SGD(model.parameters(), lr=args.lr, momentum=args.momentum, weight_decay=args.weight_decay)
 

--- a/models/cifar/preresnet.py
+++ b/models/cifar/preresnet.py
@@ -92,13 +92,19 @@ class Bottleneck(nn.Module):
 
 class PreResNet(nn.Module):
 
-    def __init__(self, depth, num_classes=1000):
+    def __init__(self, depth, num_classes=1000, block_name='BasicBlock'):
         super(PreResNet, self).__init__()
         # Model type specifies number of layers for CIFAR-10 model
-        assert (depth - 2) % 6 == 0, 'depth should be 6n+2'
-        n = (depth - 2) // 6
-
-        block = Bottleneck if depth >=44 else BasicBlock
+        if block_name.lower() == 'basicblock':
+            assert (depth - 2) % 6 == 0, 'When use basicblock, depth should be 6n+2, e.g. 20, 32, 44, 56, 110, 1202'
+            n = (depth - 2) // 6
+            block = BasicBlock
+        elif block_name.lower() == 'bottleneck':
+            assert (depth - 2) % 9 == 0, 'When use bottleneck, depth should be 9n+2, e.g. 20, 29, 47, 56, 110, 1199'
+            n = (depth - 2) // 9
+            block = Bottleneck
+        else:
+            raise ValueError('block_name shoule be Basicblock or Bottleneck')
 
         self.inplanes = 16
         self.conv1 = nn.Conv2d(3, 16, kernel_size=3, padding=1,

--- a/models/cifar/resnet.py
+++ b/models/cifar/resnet.py
@@ -92,13 +92,20 @@ class Bottleneck(nn.Module):
 
 class ResNet(nn.Module):
 
-    def __init__(self, depth, num_classes=1000):
+    def __init__(self, depth, num_classes=1000, block_name='BasicBlock'):
         super(ResNet, self).__init__()
         # Model type specifies number of layers for CIFAR-10 model
-        assert (depth - 2) % 6 == 0, 'depth should be 6n+2'
-        n = (depth - 2) // 6
+        if block_name.lower() == 'basicblock':
+            assert (depth - 2) % 6 == 0, 'When use basicblock, depth should be 6n+2, e.g. 20, 32, 44, 56, 110, 1202'
+            n = (depth - 2) // 6
+            block = BasicBlock
+        elif block_name.lower() == 'bottleneck':
+            assert (depth - 2) % 9 == 0, 'When use bottleneck, depth should be 9n+2, e.g. 20, 29, 47, 56, 110, 1199'
+            n = (depth - 2) // 9
+            block = Bottleneck
+        else:
+            raise ValueError('block_name shoule be Basicblock or Bottleneck')
 
-        block = Bottleneck if depth >=44 else BasicBlock
 
         self.inplanes = 16
         self.conv1 = nn.Conv2d(3, 16, kernel_size=3, padding=1,


### PR DESCRIPTION
Hi~ thanks for your nice code! 
I made some modification, according to the discussion in #6 and #8: 
- The default building block for resnet on cifar10/cifar100 is `BasicBlock` 
- `Depth=6n+2` when using `basicblock` and `Depth=9n+2` when using `bottleneck`
- Add an command line option to choose building block. 

And I do some experiments using resnet and cifar10. The training receipts and results are:

``` bash
python cifar.py -a resnet --depth 164 --block-name Bottleneck --epochs 164 --schedule 81 122 --gamma 0.1 --wd 1e-4 --checkpoint checkpoints/cifar10/resnet-164-bottleneck 

python cifar.py -a resnet --depth 110 --block-name BasicBlock --epochs 164 --schedule 81 122 --gamma 0.1 --wd 1e-4 --checkpoint checkpoints/cifar10/resnet-110-basicblock

python cifar.py -a resnet --depth 110 --block-name Bottleneck --epochs 164 --schedule 81 122 --gamma 0.1 --wd 1e-4 --checkpoint checkpoints/cifar10/resnet-110-bottleneck 
```

block name| depth| params(M)|best top-1 error(%)
--|--|--|--
Bottleneck|164|1.70|6.26
Bottleneck|110|1.14|6.71
BasicBlock|110|1.73|6.60

