### PR TITLE
Replaced deprecated parameter async by 'non_blocking' 

### DIFF
--- a/cifar.py
+++ b/cifar.py
@@ -245,7 +245,7 @@ def train(trainloader, model, criterion, optimizer, epoch, use_cuda):
         data_time.update(time.time() - end)
 
         if use_cuda:
-            inputs, targets = inputs.cuda(), targets.cuda(async=True)
+            inputs, targets = inputs.cuda(), targets.cuda(non_blocking=True)
         inputs, targets = torch.autograd.Variable(inputs), torch.autograd.Variable(targets)
 
         # compute output


### PR DESCRIPTION
Resolved syntax error in Python 3.7.4