### PR TITLE
Refactor Outdated PyTorch Operations for AlexNet Training on CIFAR

### DIFF
--- a/cifar.py
+++ b/cifar.py
@@ -245,7 +245,7 @@ def train(trainloader, model, criterion, optimizer, epoch, use_cuda):
         data_time.update(time.time() - end)
 
         if use_cuda:
-            inputs, targets = inputs.cuda(), targets.cuda(async=True)
+            inputs, targets = inputs.cuda(), targets.cuda()
         inputs, targets = torch.autograd.Variable(inputs), torch.autograd.Variable(targets)
 
         # compute output

--- a/cifar.py
+++ b/cifar.py
@@ -303,7 +303,9 @@ def test(testloader, model, criterion, epoch, use_cuda):
 
         if use_cuda:
             inputs, targets = inputs.cuda(), targets.cuda()
-        inputs, targets = torch.autograd.Variable(inputs, volatile=True), torch.autograd.Variable(targets)
+        with torch.no_grad():
+            inputs, targets = torch.autograd.Variable(inputs), torch.autograd.Variable(targets)
+
 
         # compute output
         outputs = model(inputs)

--- a/cifar.py
+++ b/cifar.py
@@ -311,9 +311,9 @@ def test(testloader, model, criterion, epoch, use_cuda):
 
         # measure accuracy and record loss
         prec1, prec5 = accuracy(outputs.data, targets.data, topk=(1, 5))
-        losses.update(loss.data[0], inputs.size(0))
-        top1.update(prec1[0], inputs.size(0))
-        top5.update(prec5[0], inputs.size(0))
+        losses.update(loss.item(), inputs.size(0))
+        top1.update(prec1.item(), inputs.size(0))
+        top5.update(prec5.item(), inputs.size(0))
 
         # measure elapsed time
         batch_time.update(time.time() - end)

--- a/cifar.py
+++ b/cifar.py
@@ -254,9 +254,9 @@ def train(trainloader, model, criterion, optimizer, epoch, use_cuda):
 
         # measure accuracy and record loss
         prec1, prec5 = accuracy(outputs.data, targets.data, topk=(1, 5))
-        losses.update(loss.data[0], inputs.size(0))
-        top1.update(prec1[0], inputs.size(0))
-        top5.update(prec5[0], inputs.size(0))
+        losses.update(loss.item(), inputs.size(0))
+        top1.update(prec1.item(), inputs.size(0))
+        top5.update(prec5.item(), inputs.size(0))
 
         # compute gradient and do SGD step
         optimizer.zero_grad()

--- a/utils/eval.py
+++ b/utils/eval.py
@@ -9,10 +9,10 @@ def accuracy(output, target, topk=(1,)):
 
     _, pred = output.topk(maxk, 1, True, True)
     pred = pred.t()
-    correct = pred.eq(target.view(1, -1).expand_as(pred))
+    correct = pred.eq(target.reshape(1, -1).expand_as(pred))
 
     res = []
     for k in topk:
-        correct_k = correct[:k].view(-1).float().sum(0)
+        correct_k = correct[:k].reshape(-1).float().sum(0)
         res.append(correct_k.mul_(100.0 / batch_size))
     return res


### PR DESCRIPTION
This pull request includes several important updates and fixes to ensure compatibility with the latest version of PyTorch and to resolve issues related to tensor operations while training AlexNet on the CIFAR dataset. 

The key changes are as follows:

1. Removed `async=True` argument from `cuda()` calls: This argument is deprecated in PyTorch 1.0.0 and has been removed to maintain compatibility.
   - Commit: `5c70d06`

2. Refactored code to use `torch.no_grad()` instead of `volatile=True`: Updated to the new context manager approach to handle operations without tracking gradients for better efficiency with the latest PyTorch version.
   - Commit: `4d393ff`

3. Fixed tensor reshaping in the accuracy function: Replaced `view` with `reshape` to correct issues when reshaping tensors, improving reliability.
   - Commit: `d378d87`

4. Addressed all 0-dim tensor indexing errors in cifar.py: Accessing 0-dim tensors caused index errors, ensuring smooth operation during training and metrics update.
   - Commits: `c570bd6`, `2935578`

Additional Information:
- Files Changed:
  - cifar.py: Updated to remove deprecated or obsolete arguments and fix tensor operations
  - eval.py: Adjusted tensor reshaping logic for accuracy calculation